### PR TITLE
Update attribute variable name to follow spec

### DIFF
--- a/setattributes.js
+++ b/setattributes.js
@@ -1,14 +1,14 @@
 module.exports = function setAttributes(element, attributes) {
   var value;
 
-  for (var key in attributes) {
-    if (Object.prototype.hasOwnProperty.call(attributes, key)) {
-      value = attributes[key];
+  for (var name in attributes) {
+    if (Object.prototype.hasOwnProperty.call(attributes, name)) {
+      value = attributes[name];
 
       if (value == null) {
-        element.removeAttribute(key);
+        element.removeAttribute(name);
       } else {
-        element.setAttribute(key, value);
+        element.setAttribute(name, value);
       }
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -6,11 +6,11 @@ describe("setAttributes", function () {
   beforeEach(function () {
     this.el = {
       attributes: {},
-      setAttribute: function (key, value) {
-        this.attributes[key] = value;
+      setAttribute: function (name, value) {
+        this.attributes[name] = value;
       },
-      removeAttribute: function (key) {
-        delete this.attributes[key];
+      removeAttribute: function (name) {
+        delete this.attributes[name];
       },
     };
   });


### PR DESCRIPTION
Following [WHATWG Living standard spec](https://dom.spec.whatwg.org/#dom-element-setattribute):

> setAttribute(qualifiedName, value)

As discussed in #2, `name` is closer to the spec and more explicit than `key`.